### PR TITLE
Fixed issues with cloning/deconstruction of EnumField

### DIFF
--- a/django_types/utils.py
+++ b/django_types/utils.py
@@ -17,6 +17,7 @@ class DBType(str):
             self.params = params
         else:
             self = super().__new__(cls, value)
+            self.params = []
         self.db_type = value
         return self
 

--- a/tests/test_dbtype.py
+++ b/tests/test_dbtype.py
@@ -1,0 +1,34 @@
+"""Tests related to django_types.utils.DBType"""
+from django.test import TestCase
+
+from django_types.utils import DBType
+
+
+class DBTypeTest(TestCase):
+    def test_str(self):
+        db_type = DBType('test_enum(%s, %s)', ['val1', 'val2'])
+        expected = 'test_enum(val1, val2)'
+        self.assertEqual(str(db_type), expected)
+
+    def test_paramatized_no_params(self):
+        db_type = DBType('test_enum', None)
+        expected = ('test_enum', [])
+        self.assertEqual(db_type.paramatized, expected)
+
+    def test_paramatized_with_params(self):
+        db_type = DBType('test_enum(%s, %s)', ['val1', 'val2'])
+        expected = ('test_enum(%s, %s)', ['val1', 'val2'])
+        self.assertEqual(db_type.paramatized, expected)
+
+    def test_paramatized_no_params_reuse(self):
+        """
+        Tests that the parameters used by DBType without any parameters are not reused between instances.
+
+        Reusing the params instance causes problem during migration execution, as the BaseDatabaseSchemaEditor
+        adds default values to the parameters list.
+        """
+        db_type_1 = DBType('enum_1')
+        db_type_2 = DBType('enum_2')
+        paramatized_1 = db_type_1.paramatized
+        paramatized_2 = db_type_2.paramatized
+        self.assertFalse(paramatized_1[1] is paramatized_2[1])

--- a/tests/test_enumfield.py
+++ b/tests/test_enumfield.py
@@ -75,3 +75,48 @@ class EnumFieldTest(FieldTestCase):
         choices = field.get_choices(blank_choice=BLANK_CHOICE_DASH)
         expected = BLANK_CHOICE_DASH + [(str(em), em.value) for em in members]
         self.assertEqual(choices, expected)
+
+    def test_default_stringify(self):
+        """
+        Tests that the default value is converted to string when an Enum member is passed as the default.
+        """
+        field = EnumField(TestEnum, default=TestEnum.VAL2)
+        self.assertEqual(field.default, TestEnum.VAL2.value)
+
+    def test_clone_default(self):
+        """
+        Tests that the default value is not lost when cloning the field.
+        """
+        field = EnumField(TestEnum, default=TestEnum.VAL2.value)
+        cloned_field = field.clone()
+        self.assertEqual(cloned_field.default, TestEnum.VAL2.value)
+
+    def test_clone_choices(self):
+        """
+        Tests that the choices list is not lost when cloning the field.
+        """
+        members = [TestEnum.VAL1, TestEnum.VAL2]
+        field = EnumField(TestEnum, choices=members)
+        cloned_field = field.clone()
+        expected = [(str(em), em.value) for em in members]
+        self.assertEqual(cloned_field.choices, expected)
+
+    def test_deconstruct_manual_choices_without_enum(self):
+        """
+        Tests that the choices list is not lost when deconstructing a field that is not bound to an enum. This occurs
+        when the schema is reconstructed from migrations and losing the value might cause the field to be marked
+        as updated even when there is no change.
+        """
+        choices_list = [('VAL1', 'Value 1'), ('VAL2', 'Value 2')]
+        field = EnumField(choices=choices_list)
+        name, path, args, kwargs = field.deconstruct()
+        expected_kwargs = {'choices': choices_list}
+        self.assertEqual(kwargs, expected_kwargs)
+
+    def test_clone_type_def(self):
+        """
+        Tests that the type def field is cloned properly when cloning the field.
+        """
+        field = EnumField(TestEnum)
+        cloned_field = field.clone()
+        self.assertEqual(cloned_field.type_def, TestEnum)


### PR DESCRIPTION
I have fixed several issues with cloning and deconstruction of EnumField instances. I fixed issue #3 and two more issues regarding the default values of enums I have discovered.

Everything is described in the commit messages.