### PR TITLE
Fix error when add value to existing enum

### DIFF
--- a/django_enum/patches.py
+++ b/django_enum/patches.py
@@ -74,7 +74,7 @@ class PostgresDatabaseSchemaEditor:
     sql_delete_enum = 'DROP TYPE %(enum_type)s'
     # ALTER TYPE for schema changes. pg9.1+ only
     # https://www.postgresql.org/docs/9.1/static/sql-altertype.html
-    sql_alter_enum = 'ALTER TYPE %(enum_type)s ADD VALUE %(value)s %(condition)s'
+    sql_alter_enum = 'ALTER TYPE %(enum_type)s ADD VALUE %(value)s'
     sql_rename_enum = 'ALTER TYPE %(old_type)s RENAME TO %(enum_type)s'
     # remove_from_enum is not supported by poostgres
 


### PR DESCRIPTION
Hi @ashleywaite. Thanks for a very useful lib for enums. 
But now we have a problem for adding new values to existing enums. Pls see the description below.

Now condition not implemented and raised error

```
sql = schema_editor.sql_alter_enum % {
KeyError: 'condition'
```

This happens because of no condition for formating string

```
ALTER TYPE %(enum_type)s ADD VALUE %(value)s %(condition)s' % {'enum_type': self.db_type, 'value': '%s'}
```

https://github.com/ashleywaite/django-more/blob/master/django_enum/operations.py#L319-L321